### PR TITLE
Update actions test workflow 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,29 +18,17 @@ jobs:
     strategy:
       matrix:
         include:
-          # iRODS 4.2.10 clients vs 4.2.7 server
-          - go: "1.17"
-            irods: "4.2.10"
-            server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "3.2.0"
-            experimental: false
-          # iRODS 4.2.10 clients vs 4.2.10 server
-          - go: "1.17"
-            irods: "4.2.10"
-            server_image: "wsinpg/ub-18.04-irods-4.2.10:latest"
-            baton: "3.2.0"
-            experimental: false
           # iRODS 4.2.11 clients vs 4.2.7 server
           - go: "1.17"
             irods: "4.2.11"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
           # iRODS 4.2.11 clients vs 4.2.11 server
           - go: "1.17"
             irods: "4.2.11"
             server_image: "wsinpg/ub-18.04-irods-4.2.11:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
 
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+ - Update github actions test workflow baton to 3.3.0
+
+### Removed
+
+ - Remove irods 4.2.10 from github actions test workflow
+
 ### [1.8.0] - 2022-06-20
 
 ### Added


### PR DESCRIPTION
Change baton version to 3.3.0 and remove irods-clients 4.2.10 from github actions tests