### PR TITLE
Remove references to conda from the archive creation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+ - Update valet_archive_create script to remove reference to conda
  - Update CI to use ubuntu latest
  - Update github actions test workflow baton to 4.0.0
 

--- a/scripts/valet_archive_create.sh
+++ b/scripts/valet_archive_create.sh
@@ -28,9 +28,6 @@
 set -e
 
 # BEGIN ENVIRONMENT
-CONDA_ROOT=${CONDA_ROOT:-$HOME/miniconda}
-CONDA_ENV=${CONDA_ENV:-valet}
-
 HOSTNAME=${HOSTNAME:-$(hostname)}
 INSTRUMENT_MODEL=${INSTRUMENT_MODEL:-promethion}
 
@@ -45,12 +42,9 @@ LOG_FILE=${LOG_FILE:-"$HOME/valet.log"}
 TMPDIR=${TMPDIR:-"$SAFE_ROOT/tmp"}
 # END ENVIRONMENT
 
-source "$CONDA_ROOT/etc/profile.d/conda.sh"
-
 set -x
 
-conda activate "$CONDA_ENV" && \
-  TMPDIR="$TMPDIR" nice valet archive create \
+TMPDIR="$TMPDIR" nice valet archive create \
   --root "$DATA_ROOT" \
   --archive-root "$ARCHIVE_ROOT" \
   --exclude "$SAFE_ROOT" \


### PR DESCRIPTION
Allow valet to start without a conda installation